### PR TITLE
Use Numpy instead of List to improve performance

### DIFF
--- a/mritopng/__init__.py
+++ b/mritopng/__init__.py
@@ -20,8 +20,8 @@ def mri_to_png(mri_file, png_file):
     # Rescaling grey scale between 0-255
     image_2d_scaled = ( image_2d / image_2d.max() ) * 255.0
     
-    #Convert to uint8
-    image_2d_scaled = np.uint8(image_2d_scaled)
+    #Convert to int to handle negative values as well
+    image_2d_scaled = image_2d_scaled.astype(int)
 
     # Writing the PNG file
     w = png.Writer(shape[1], shape[0], greyscale=True)

--- a/mritopng/__init__.py
+++ b/mritopng/__init__.py
@@ -1,7 +1,7 @@
 import os
 import png
 import dicom
-
+import numpy as np
 
 def mri_to_png(mri_file, png_file):
     """ Function to convert from a DICOM image to png
@@ -14,25 +14,14 @@ def mri_to_png(mri_file, png_file):
     plan = dicom.read_file(mri_file)
     shape = plan.pixel_array.shape
 
-    image_2d = []
-    max_val = 0
-    for row in plan.pixel_array:
-        pixels = []
-        for col in row:
-            pixels.append(col)
-            if col > max_val:
-                max_val = col
-        image_2d.append(pixels)
+    #Convert to float to avoid overflow or underflow losses.
+    image_2d = plan.pixel_array.astype(float)
 
     # Rescaling grey scale between 0-255
-    image_2d_scaled = []
-    for row in image_2d:
-        row_scaled = []
-        for col in row:
-            # cliping pixel value if below 0
-            col_scaled = int((float(max(col, 0)) / float(max_val)) * 255.0)
-            row_scaled.append(col_scaled)
-        image_2d_scaled.append(row_scaled)
+    image_2d_scaled = ( image_2d / image_2d.max() ) * 255.0
+    
+    #Convert to uint8
+    image_2d_scaled = np.uint8(image_2d_scaled)
 
     # Writing the PNG file
     w = png.Writer(shape[1], shape[0], greyscale=True)

--- a/mritopng/__init__.py
+++ b/mritopng/__init__.py
@@ -18,10 +18,10 @@ def mri_to_png(mri_file, png_file):
     image_2d = plan.pixel_array.astype(float)
 
     # Rescaling grey scale between 0-255
-    image_2d_scaled = ( image_2d / image_2d.max() ) * 255.0
+    image_2d_scaled = ( np.maximum(image_2d,0) / image_2d.max() ) * 255.0
     
-    #Convert to int to handle negative values as well
-    image_2d_scaled = image_2d_scaled.astype(int)
+    #Convert to uint
+    image_2d_scaled = np.uint8(image_2d_scaled)
 
     # Writing the PNG file
     w = png.Writer(shape[1], shape[0], greyscale=True)

--- a/mritopng/__init__.py
+++ b/mritopng/__init__.py
@@ -18,7 +18,7 @@ def mri_to_png(mri_file, png_file):
     image_2d = plan.pixel_array.astype(float)
 
     # Rescaling grey scale between 0-255
-    image_2d_scaled = ( np.maximum(image_2d,0) / image_2d.max() ) * 255.0
+    image_2d_scaled = (np.maximum(image_2d,0) / image_2d.max()) * 255.0
     
     #Convert to uint
     image_2d_scaled = np.uint8(image_2d_scaled)


### PR DESCRIPTION
Since the code already depends on Numpy , we can use Numpy instead of creating and appending lists for scaling the image data from Dicom to improve the performance.

Before using Numpy for converting 10 files it took 98.287921104 s
After using Numpy the same task with same images takes 12.0352997347 s