### PR TITLE
Remove stray file

### DIFF
--- a/mritopng/__init__.py
+++ b/mritopng/__init__.py
@@ -92,3 +92,4 @@ def convert_folder(mri_folder, png_folder, auto_contrast=False):
                     print('SUCCESS: %s --> %s' % (mri_file_path, png_file_path))
                 except Exception as e:
                     print('FAIL: %s --> %s : %s' % (mri_file_path, png_file_path, e))
+                    os.remove(png_file_path)

--- a/mritopng/__init__.py
+++ b/mritopng/__init__.py
@@ -92,4 +92,4 @@ def convert_folder(mri_folder, png_folder, auto_contrast=False):
                     print('SUCCESS: %s --> %s' % (mri_file_path, png_file_path))
                 except Exception as e:
                     print('FAIL: %s --> %s : %s' % (mri_file_path, png_file_path, e))
-                    os.remove(png_file_path)
+                    os.remove(png_file_path) if os.path.exists(png_file_path) else None

--- a/tests/test_mritopng.py
+++ b/tests/test_mritopng.py
@@ -128,3 +128,17 @@ class TestMRIToPNG(unittest.TestCase):
 
         if not np.array_equal(result.image, expected):
             raise Exception("Expected:\n%s\n\nActual:\n%s\n"%(expected, result.image))
+
+    def test_folder_convert(self):
+        curr_path = os.path.dirname(os.path.realpath(__file__))
+        mri_dir_path = os.path.join(curr_path, 'data', 'samples')
+        png_dir_path = os.path.join(curr_path, 'data', 'png_dir')
+
+        mritopng.convert_folder(mri_dir_path, png_dir_path)
+        
+        valid_files = ['dicom1.png', '000012.dcm.png', '000017.dcm.png']
+        converted_files = os.listdir(png_dir_path)
+
+        # cleanup before assertion.
+        shutil.rmtree(png_dir_path)
+        self.assertEqual(valid_files, converted_files, 'Invalid dicom left a stray png file.')

--- a/tests/test_mritopng.py
+++ b/tests/test_mritopng.py
@@ -136,8 +136,8 @@ class TestMRIToPNG(unittest.TestCase):
 
         mritopng.convert_folder(mri_dir_path, png_dir_path)
         
-        valid_files = ['dicom1.png', '000012.dcm.png', '000017.dcm.png']
-        converted_files = os.listdir(png_dir_path)
+        valid_files = {'dicom1.png', '000012.dcm.png', '000017.dcm.png'}
+        converted_files = set(os.listdir(png_dir_path))
 
         # cleanup before assertion.
         shutil.rmtree(png_dir_path)


### PR DESCRIPTION
Fixes #7 .

Adds / Changes:
* Removes the stray png file from a failed conversion
* Test to validate the above fix.