### PR TITLE
Use numpy for auto-contrast

### DIFF
--- a/mritopng/contrast.py
+++ b/mritopng/contrast.py
@@ -1,36 +1,20 @@
 import numpy as np
 from .models import GrayscaleImage
 
-def histogram(image):
-    
-    hist = dict()
-
-    # Initialize dict
-    for shade in range(0, 256):
-        hist[shade] = 0
-    
-    for index, val in np.ndenumerate(image.image):
-        hist[val] += 1
-      
-    return hist
-
-
 def shade_at_percentile(hist, percentile):
-
-    n = sum(hist.values())
-    cumulative_sum = 0.0
-    for shade in range(0, 256):
-        cumulative_sum += hist[shade]
-        if cumulative_sum/n >= percentile:
-            return shade
+    """ Assumes the argument percentile,
+        to be less 1.
+    """
+    n = np.sum(hist)
+    cumulative_sum = np.cumsum(hist)
     
-    return None
+    return np.argmax(cumulative_sum/n >= percentile)
 
 def auto_contrast(image):
     """ Apply auto contrast to an image using
         https://stackoverflow.com/questions/9744255/instagram-lux-effect/9761841#9761841
     """
-    hist = histogram(image)
+    hist, _ = np.histogram(image.image.ravel(), bins=np.arange(0, 256))
     p5 = shade_at_percentile(hist, .01)
     p95 = shade_at_percentile(hist, .99)
     a = 255.0/(p95 + p5)

--- a/mritopng/contrast.py
+++ b/mritopng/contrast.py
@@ -15,10 +15,10 @@ def auto_contrast(image):
         https://stackoverflow.com/questions/9744255/instagram-lux-effect/9761841#9761841
     """
     hist, _ = np.histogram(image.image.ravel(), bins=np.arange(0, 256))
-    p5 = shade_at_percentile(hist, .01)
-    p95 = shade_at_percentile(hist, .99)
-    a = 255.0/(p95 + p5)
-    b = -1.0 * a * p5
+    p01 = shade_at_percentile(hist, .01)
+    p99 = shade_at_percentile(hist, .99)
+    a = 255.0/(p99 + p01)
+    b = -1.0 * a * p01
 
     result = (image.image.astype(float) * a) + b
     result = result.clip(0, 255.0)

--- a/tests/test_mritopng.py
+++ b/tests/test_mritopng.py
@@ -96,10 +96,10 @@ class TestMRIToPNG(unittest.TestCase):
         curr_path = os.path.dirname(os.path.realpath(__file__))
         sample_path = os.path.join(curr_path, 'data', 'samples', '000017.dcm')
         image = mritopng.extract_grayscale_image(sample_path)
-        histogram = contrast.histogram(image)
+        histogram, _ = np.histogram(image.image.ravel(), np.arange(0,256))
 
-        for shade in histogram:
-            print('%d\t%d' % (shade, histogram[shade]))
+        for bin, shade in enumerate(histogram):
+            print('%d\t%d' % (shade, histogram[bin]))
         
         a = contrast.shade_at_percentile(histogram, 0.05)
         b = contrast.shade_at_percentile(histogram, 0.95)


### PR DESCRIPTION
Using existing numpy functions will allow to reduce the code and lead to easier maintenance, without reinventing the wheel.

Haven't extensively benchmarked but the tests run significantly faster on my system (from 2 sec to 25 msec ) using numpy functions. ( Please look at the attached files)

Duration of the test is timed using command
`stdbuf -oL pytest test_mritopng.py --durations=0 > <filename>`

[master.log](https://github.com/danishm/mritopng/files/2904897/master.log)
[use-numpy.log](https://github.com/danishm/mritopng/files/2904898/use-numpy.log)

